### PR TITLE
Make Yeah! button unselectable/undraggable

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -218,6 +218,7 @@ function hookIntoTweets() {
         img.src = tweetCache[id] && tweetCache[id].yeahed ? chrome.runtime.getURL('images/yeah_on32.png') : chrome.runtime.getURL('images/yeah_off32.png');
         if(tweetCache[id] && tweetCache[id].yeahed) button.classList.add('yeahed');
         img.className = 'yeah-image';
+        img.draggable = false;
         button.appendChild(img);
 
         let counter = document.createElement('span');

--- a/styles/style.css
+++ b/styles/style.css
@@ -26,6 +26,9 @@ body[style^="background-color: rgb(0, 0, 0);"], body.body-pitch-black {
     flex-direction: row;
     flex: 1;
     justify-content: flex-start;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
 }
 
 .yeah-button-container-oldtwitter {


### PR DESCRIPTION
Currently the Yeah! button allows you to select it and also drag the image icon around:

https://github.com/dimdenGD/YeahTwitter/assets/47027981/00ad5857-86d7-4b00-a7c9-c5c2255c35fe

This PR just makes the button not selectable and draggable so that it acts more like the other interaction buttons on Twitter